### PR TITLE
Use shared product data and apply tax-inclusive pricing

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -1,33 +1,57 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const tableBody = document.getElementById('product-table-body');
+
+  PRODUCT_DATA.forEach((product, index) => {
+    const row = document.createElement('tr');
+
+    const nameCell = document.createElement('td');
+    nameCell.textContent = product.name;
+    row.appendChild(nameCell);
+
+    const packSizeCell = document.createElement('td');
+    packSizeCell.textContent = product.packSize;
+    row.appendChild(packSizeCell);
+
+    const priceCell = document.createElement('td');
+    priceCell.textContent = `₹${formatCurrency(getTaxedUnitPrice(product.baseUnitPrice))}`;
+    row.appendChild(priceCell);
+
+    const quantityCell = document.createElement('td');
+    const quantityInput = document.createElement('input');
+    quantityInput.type = 'number';
+    quantityInput.id = getQuantityInputId(index);
+    quantityInput.name = getQuantityInputId(index);
+    quantityInput.min = '0';
+    quantityCell.appendChild(quantityInput);
+    row.appendChild(quantityCell);
+
+    tableBody.appendChild(row);
+  });
+});
+
 function calculateTotal() {
-  // Get input values
-  const product1Qty = parseInt(document.getElementById('product1').value) || 0;
-  const product2Qty = parseInt(document.getElementById('product2').value) || 0;
-  const product3Qty = parseInt(document.getElementById('product3').value) || 0;
-  const product4Qty = parseInt(document.getElementById('product4').value) || 0;
-  const product5Qty = parseInt(document.getElementById('product5').value) || 0;
-  
-  // Prices of each product
-  const productPrices = [340.96, 152.44, 33.87, 493.29, 361.57];
-  const packSizes = [30, 20, 100, 12, 12];
-  const productNames = ['VOLUVEN 6% 250 ML', 'KABILYTE 500 ML', 'KABIPARA 100 ML BOTT', 'INTRALIPID 20% 250 ML', 'AMINOWEL 5% 250 ML'];
-  
-  // Calculate total price for each product
-  const productTotalPrices = [
-    Math.round(product1Qty * packSizes[0] * productPrices[0] * 100) / 100,
-    Math.round(product2Qty * packSizes[1] * productPrices[1] * 100) / 100,
-    Math.round(product3Qty * packSizes[2] * productPrices[2] * 100) / 100,
-    Math.round(product4Qty * packSizes[3] * productPrices[3] * 100) / 100,
-    Math.round(product5Qty * packSizes[4] * productPrices[4] * 100) / 100
-  ];
-  
-  // Calculate overall total
-  const overallTotal = productTotalPrices.reduce((total, price) => total + price, 0);
-  
-  // Display results
   const resultsDiv = document.getElementById('results');
   resultsDiv.innerHTML = '';
-  for (let i = 0; i < productTotalPrices.length; i++) {
-    resultsDiv.innerHTML += `${productNames[i]} Total: ₹ ${Math.round(productTotalPrices[i] * 100) / 100}<br>`;
-  }
-  resultsDiv.innerHTML += `Overall Total: ₹ ${Math.round(overallTotal * 100) / 100}`;
+
+  let overallTotal = 0;
+
+  PRODUCT_DATA.forEach((product, index) => {
+    const quantity = parseInt(document.getElementById(getQuantityInputId(index)).value, 10) || 0;
+    const lineTotal =
+      product.packSize * product.baseUnitPrice * quantity * getTaxMultiplier();
+
+    overallTotal += lineTotal;
+
+    resultsDiv.innerHTML += `${product.name} Total: ₹ ${formatCurrency(lineTotal)}<br>`;
+  });
+
+  resultsDiv.innerHTML += `Overall Total: ₹ ${formatCurrency(overallTotal)}`;
+}
+
+function getQuantityInputId(index) {
+  return `quantity-${index}`;
+}
+
+function formatCurrency(value) {
+  return (Math.round(value * 100) / 100).toFixed(2);
 }

--- a/index.html
+++ b/index.html
@@ -44,46 +44,16 @@
       <tr>
         <th>Product Name</th>
         <th>Pack Size</th>
-        <th>Price</th>
+        <th>Price (incl. 5% tax)</th>
         <th>Quantity (Boxes)</th>
       </tr>
     </thead>
-    <tbody>
-      <tr>
-        <td>VOLUVEN 6% 250 ML</td>
-        <td>30</td>
-        <td>₹340.96</td>
-        <td><input type="number" id="product1" name="product1" min="0"></td>
-      </tr>
-      <tr>
-        <td>KABILYTE 500 ML</td>
-        <td>20</td>
-        <td>₹152.44</td>
-        <td><input type="number" id="product2" name="product2" min="0"></td>
-      </tr>
-      <tr>
-        <td>KABIPARA 100 ML BOTT</td>
-        <td>100</td>
-        <td>₹33.87</td>
-        <td><input type="number" id="product3" name="product3" min="0"></td>
-      </tr>
-      <tr>
-        <td>INTRALIPID 20% 250 ML</td>
-        <td>12</td>
-        <td>₹493.29</td>
-        <td><input type="number" id="product4" name="product4" min="0"></td>
-      </tr>
-      <tr>
-        <td>AMINOWEL 5% 250 ML</td>
-        <td>12</td>
-        <td>₹361.57</td>
-        <td><input type="number" id="product5" name="product5" min="0"></td>
-      </tr>
-    </tbody>
+    <tbody id="product-table-body"></tbody>
   </table>
   <button type="button" onclick="calculateTotal()">Calculate</button>
   <div id="results"></div>
 </div>
+<script src="productData.js"></script>
 <script src="calculator.js"></script>
 </body>
 </html>

--- a/productData.js
+++ b/productData.js
@@ -1,0 +1,37 @@
+const TAX_RATE = 0.05;
+
+const PRODUCT_DATA = [
+  {
+    name: 'VOLUVEN 6% 250 ML',
+    packSize: 30,
+    baseUnitPrice: 324.73,
+  },
+  {
+    name: 'KABILYTE 500 ML',
+    packSize: 20,
+    baseUnitPrice: 145.18,
+  },
+  {
+    name: 'KABIPARA 100 ML BOTT',
+    packSize: 100,
+    baseUnitPrice: 32.26,
+  },
+  {
+    name: 'INTRALIPID 20% 250 ML',
+    packSize: 12,
+    baseUnitPrice: 469.8,
+  },
+  {
+    name: 'AMINOWEL 5% 250 ML',
+    packSize: 12,
+    baseUnitPrice: 344.35,
+  },
+];
+
+function getTaxMultiplier() {
+  return 1 + TAX_RATE;
+}
+
+function getTaxedUnitPrice(baseUnitPrice) {
+  return baseUnitPrice * getTaxMultiplier();
+}


### PR DESCRIPTION
## Summary
- add a shared data file containing pack sizes, pre-tax prices, and tax rate
- generate the product table dynamically with tax-inclusive display prices
- calculate totals with pre-tax prices and apply the tax multiplier for accuracy

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d52964a10c8330a4c3c03a68f8bb23