### PR TITLE
Round overall total to nearest integer

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -45,7 +45,8 @@ function calculateTotal() {
     resultsDiv.innerHTML += `${product.name} Total: ₹ ${formatCurrency(lineTotal)}<br>`;
   });
 
-  resultsDiv.innerHTML += `Overall Total: ₹ ${formatCurrency(overallTotal)}`;
+  const roundedOverallTotal = Math.round(overallTotal);
+  resultsDiv.innerHTML += `Overall Total: ₹ ${roundedOverallTotal}`;
 }
 
 function getQuantityInputId(index) {


### PR DESCRIPTION
### Motivation
- Ensure the displayed overall total is always an integer by rounding the computed total before rendering.

### Description
- In `calculateTotal` use `Math.round(overallTotal)` and render that integer for the `Overall Total`, while leaving per-product line totals formatted via `formatCurrency`.

### Testing
- Ran `node --check calculator.js` to verify there are no JavaScript syntax errors and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb58b239b08330bd279ac63a1809b3)